### PR TITLE
CreateFood returns uuid && Customize custom food only update data

### DIFF
--- a/src/main/java/com/nutriplus/NutriPlusBack/services/datafetcher/FoodDataFetcher.java
+++ b/src/main/java/com/nutriplus/NutriPlusBack/services/datafetcher/FoodDataFetcher.java
@@ -123,7 +123,7 @@ public class FoodDataFetcher {
         };
     }
 
-    public DataFetcher<Boolean> createFood() {
+    public DataFetcher<String> createFood() {
         return dataFetchingEnvironment -> {
             Authentication authentication = SecurityContextHolder.getContext().getAuthentication();
             UserCredentials user = (UserCredentials) authentication.getCredentials();
@@ -154,7 +154,7 @@ public class FoodDataFetcher {
             applicationFoodRepository.save(createdFood);
             applicationUserRepository.save(user);
 
-            return true;
+            return createdFood.getUuid();
 
         };
     }
@@ -184,17 +184,34 @@ public class FoodDataFetcher {
                     lipidsValue, fiberValue);
 
             Food originalFood = applicationFoodRepository.findByUuid(uuidFood);
-            Food customFood = new Food(user, originalFood);
+            String returnUUid = "";
 
-            customFood.setNutritionFacts(nutritionFacts);
-            customFood.setMeasureType(measureType);
-            customFood.setMeasureTotalGrams(measureTotalGrams);
-            customFood.setMeasureAmount(measureAmountValue);
+            if (originalFood.getCustom() || originalFood.getCreated()) {
+                originalFood.setNutritionFacts(nutritionFacts);
+                originalFood.setMeasureType(measureType);
+                originalFood.setMeasureTotalGrams(measureTotalGrams);
+                originalFood.setMeasureAmount(measureAmountValue);
 
-            applicationFoodRepository.save(customFood);
-            applicationUserRepository.save(user);
+                applicationFoodRepository.save(originalFood);
+                applicationUserRepository.save(user);
 
-            return customFood.getUuid();
+                returnUUid = originalFood.getUuid();
+            }
+            else {
+                Food customFood = new Food(user, originalFood);
+
+                customFood.setNutritionFacts(nutritionFacts);
+                customFood.setMeasureType(measureType);
+                customFood.setMeasureTotalGrams(measureTotalGrams);
+                customFood.setMeasureAmount(measureAmountValue);
+
+                applicationFoodRepository.save(customFood);
+                applicationUserRepository.save(user);
+
+                returnUUid = customFood.getUuid();
+            }
+
+            return returnUUid;
         };
     }
 

--- a/src/main/resources/Types.graphql
+++ b/src/main/resources/Types.graphql
@@ -38,7 +38,7 @@ type Mutation{
     updatePatient(uuidPatient: String!,input: PatientInput): Boolean
 
     # Food
-    createFood(foodInput: NewFoodInput!, nutritionInput: NutritionFactsInput!) : Boolean
+    createFood(foodInput: NewFoodInput!, nutritionInput: NutritionFactsInput!) : String
     customizeFood(uuidFood: String!, customInput: CustomFoodInput!, nutritionInput: NutritionFactsInput!) : String
     removeFood(uuidFood: String!) : Boolean
     startMeals : Boolean


### PR DESCRIPTION
Esse PR atende a duas demandas do URGS:
- `createFood` retornar o `uuid` do objeto criado;
- `customizeFood` para uma comida já customizada só atualiza as informações (ao invés de criar outra).